### PR TITLE
Release v2.4.5

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ on:
 env:
   MAJOR: ${{ 2 }}
   MINOR: ${{ 4 }}
-  FIXUP: ${{ 4 }}
+  FIXUP: ${{ 5 }}
   PACKAGE_INIT_FILE: ${{ 'divik/__init__.py' }}
   PACKAGE_INIT_FILE_VERSION_LINE: ${{ 1 }}
   PACKAGE_SETUP_FILE: ${{ 'setup.py' }}

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ docker pull gmrukwa/divik
 To install specific version, you can specify it in the command, e.g.:
 
 ```bash
-docker pull gmrukwa/divik:2.4.4
+docker pull gmrukwa/divik:2.4.5
 ```
 
 ## Python package
@@ -79,7 +79,7 @@ pip install divik
 or any stable tagged version, e.g.:
 
 ```bash
-pip install divik==2.4.4
+pip install divik==2.4.5
 ```
 
 If you want to have compatibility with

--- a/dev_setup.py
+++ b/dev_setup.py
@@ -15,6 +15,7 @@ LINUX_OPTS = {
         '-Wno-strict-prototypes',
         '-Wno-maybe-uninitialized',
         '-O3',
+        '-std=c99',
     ],
 }
 OSX_OPTS = {

--- a/divik/__init__.py
+++ b/divik/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '2.4.4'
+__version__ = '2.4.5'
 
 from ._summary import plot, reject_split
 

--- a/docs/instructions/installation.rst
+++ b/docs/instructions/installation.rst
@@ -14,7 +14,7 @@ To install latest stable version use::
 
 To install specific version, you can specify it in the command, e.g.::
 
-    docker pull gmrukwa/divik:2.4.4
+    docker pull gmrukwa/divik:2.4.5
 
 Python package
 --------------
@@ -31,7 +31,7 @@ package::
 
 or any stable tagged version, e.g.::
 
-    pip install divik==2.4.4
+    pip install divik==2.4.5
 
 If you want to have compatibility with
 `gin-config <https://github.com/google/gin-config>`_, you can install

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ LINUX_OPTS = {
         '-Wno-strict-prototypes',
         '-Wno-maybe-uninitialized',
         '-O3',
+        '-std=c99',
     ],
 }
 OSX_OPTS = {

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages, Extension
 import sys
 import numpy
 
-__version__ = '2.4.4'
+__version__ = '2.4.5'
 
 LINUX_OPTS = {
     'extra_link_args': [


### PR DESCRIPTION
`manylinux` was failing to build due to missing `-std=c99` switch.