### PR TITLE
Remove dependency on typing module

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ on:
 env:
   MAJOR: ${{ 2 }}
   MINOR: ${{ 5 }}
-  FIXUP: ${{ 6 }}
+  FIXUP: ${{ 7 }}
   PACKAGE_INIT_FILE: ${{ 'divik/__init__.py' }}
   PACKAGE_INIT_FILE_VERSION_LINE: ${{ 1 }}
   PACKAGE_SETUP_FILE: ${{ 'setup.py' }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ on:
 env:
   MAJOR: ${{ 2 }}
   MINOR: ${{ 5 }}
-  FIXUP: ${{ 7 }}
+  FIXUP: ${{ 8 }}
   PACKAGE_INIT_FILE: ${{ 'divik/__init__.py' }}
   PACKAGE_INIT_FILE_VERSION_LINE: ${{ 1 }}
   PACKAGE_SETUP_FILE: ${{ 'setup.py' }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ on:
 env:
   MAJOR: ${{ 2 }}
   MINOR: ${{ 5 }}
-  FIXUP: ${{ 5 }}
+  FIXUP: ${{ 6 }}
   PACKAGE_INIT_FILE: ${{ 'divik/__init__.py' }}
   PACKAGE_INIT_FILE_VERSION_LINE: ${{ 1 }}
   PACKAGE_SETUP_FILE: ${{ 'setup.py' }}

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ docker pull gmrukwa/divik
 To install specific version, you can specify it in the command, e.g.:
 
 ```bash
-docker pull gmrukwa/divik:2.5.7
+docker pull gmrukwa/divik:2.5.8
 ```
 
 ## Python package
@@ -79,7 +79,7 @@ pip install divik
 or any stable tagged version, e.g.:
 
 ```bash
-pip install divik==2.5.7
+pip install divik==2.5.8
 ```
 
 If you want to have compatibility with

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ docker pull gmrukwa/divik
 To install specific version, you can specify it in the command, e.g.:
 
 ```bash
-docker pull gmrukwa/divik:2.5.6
+docker pull gmrukwa/divik:2.5.7
 ```
 
 ## Python package
@@ -79,7 +79,7 @@ pip install divik
 or any stable tagged version, e.g.:
 
 ```bash
-pip install divik==2.5.6
+pip install divik==2.5.7
 ```
 
 If you want to have compatibility with

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ docker pull gmrukwa/divik
 To install specific version, you can specify it in the command, e.g.:
 
 ```bash
-docker pull gmrukwa/divik:2.5.5
+docker pull gmrukwa/divik:2.5.6
 ```
 
 ## Python package
@@ -79,7 +79,7 @@ pip install divik
 or any stable tagged version, e.g.:
 
 ```bash
-pip install divik==2.5.5
+pip install divik==2.5.6
 ```
 
 If you want to have compatibility with

--- a/divik/__init__.py
+++ b/divik/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '2.5.5'
+__version__ = '2.5.6'
 
 from ._summary import plot, reject_split
 

--- a/divik/__init__.py
+++ b/divik/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '2.5.7'
+__version__ = '2.5.8'
 
 from ._summary import plot, reject_split
 

--- a/divik/__init__.py
+++ b/divik/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '2.5.6'
+__version__ = '2.5.7'
 
 from ._summary import plot, reject_split
 

--- a/divik/feature_selection/_exims/_sklearn.py
+++ b/divik/feature_selection/_exims/_sklearn.py
@@ -24,6 +24,18 @@ class EximsSelector(BaseEstimator, SelectorMixin):
     def __init__(self):
         super(EximsSelector, self).__init__()
 
+    def _get_support_mask(self):
+        """
+        Get the boolean mask indicating which features are selected
+
+        Returns
+        -------
+        support : boolean array of shape [# input features]
+            An element is True iff its corresponding feature is selected for
+            retention.
+        """
+        return self.selected_
+
     def fit(self, X, y=None, xy=None):
         """Learn data-driven feature thresholds from X.
 

--- a/divik/feature_selection/_exims/_structness.py
+++ b/divik/feature_selection/_exims/_structness.py
@@ -27,7 +27,7 @@ def _greycomatrix(discrete_image: np.ndarray, mask: np.ndarray) -> np.ndarray:
     gcm = _greycomatrix_backend(discrete_image, levels=levels)
     if not all_allowed:
         gcm = gcm[:-1, :-1, :, :]
-    return np.dstack(gcm[:, :, i, i] for i in range(gcm.shape[2]))
+    return np.dstack([gcm[:, :, i, i] for i in range(gcm.shape[2])])
 
 
 def _ignorance_mask(image: np.ndarray, ignored: List) -> np.ndarray:

--- a/docs/instructions/installation.rst
+++ b/docs/instructions/installation.rst
@@ -14,7 +14,7 @@ To install latest stable version use::
 
 To install specific version, you can specify it in the command, e.g.::
 
-    docker pull gmrukwa/divik:2.5.7
+    docker pull gmrukwa/divik:2.5.8
 
 Python package
 --------------
@@ -31,7 +31,7 @@ package::
 
 or any stable tagged version, e.g.::
 
-    pip install divik==2.5.7
+    pip install divik==2.5.8
 
 If you want to have compatibility with
 `gin-config <https://github.com/google/gin-config>`_, you can install

--- a/docs/instructions/installation.rst
+++ b/docs/instructions/installation.rst
@@ -14,7 +14,7 @@ To install latest stable version use::
 
 To install specific version, you can specify it in the command, e.g.::
 
-    docker pull gmrukwa/divik:2.5.6
+    docker pull gmrukwa/divik:2.5.7
 
 Python package
 --------------
@@ -31,7 +31,7 @@ package::
 
 or any stable tagged version, e.g.::
 
-    pip install divik==2.5.6
+    pip install divik==2.5.7
 
 If you want to have compatibility with
 `gin-config <https://github.com/google/gin-config>`_, you can install

--- a/docs/instructions/installation.rst
+++ b/docs/instructions/installation.rst
@@ -14,7 +14,7 @@ To install latest stable version use::
 
 To install specific version, you can specify it in the command, e.g.::
 
-    docker pull gmrukwa/divik:2.5.5
+    docker pull gmrukwa/divik:2.5.6
 
 Python package
 --------------
@@ -31,7 +31,7 @@ package::
 
 or any stable tagged version, e.g.::
 
-    pip install divik==2.5.5
+    pip install divik==2.5.6
 
 If you want to have compatibility with
 `gin-config <https://github.com/google/gin-config>`_, you can install

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages, Extension
 import sys
 import numpy
 
-__version__ = '2.5.7'
+__version__ = '2.5.8'
 
 LINUX_OPTS = {
     'extra_link_args': [
@@ -101,7 +101,6 @@ setup(
         'scikit-image>=0.14.1',
         'scikit-learn>=0.19.1',
         'tqdm>=4.11.2',
-        'typing>=3.6.2'
     ],
     setup_requires=[
         'numpy>=0.12.1',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages, Extension
 import sys
 import numpy
 
-__version__ = '2.5.5'
+__version__ = '2.5.6'
 
 LINUX_OPTS = {
     'extra_link_args': [

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages, Extension
 import sys
 import numpy
 
-__version__ = '2.5.6'
+__version__ = '2.5.7'
 
 LINUX_OPTS = {
     'extra_link_args': [


### PR DESCRIPTION
It was causing build issues, as it was required up to Python 3.4.