### PR TITLE
Release 2.5.8

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ on:
 env:
   MAJOR: ${{ 2 }}
   MINOR: ${{ 5 }}
-  FIXUP: ${{ 7 }}
+  FIXUP: ${{ 8 }}
   PACKAGE_INIT_FILE: ${{ 'divik/__init__.py' }}
   PACKAGE_INIT_FILE_VERSION_LINE: ${{ 1 }}
   PACKAGE_SETUP_FILE: ${{ 'setup.py' }}

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ docker pull gmrukwa/divik
 To install specific version, you can specify it in the command, e.g.:
 
 ```bash
-docker pull gmrukwa/divik:2.5.7
+docker pull gmrukwa/divik:2.5.8
 ```
 
 ## Python package
@@ -79,7 +79,7 @@ pip install divik
 or any stable tagged version, e.g.:
 
 ```bash
-pip install divik==2.5.7
+pip install divik==2.5.8
 ```
 
 If you want to have compatibility with

--- a/divik/__init__.py
+++ b/divik/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '2.5.7'
+__version__ = '2.5.8'
 
 from ._summary import plot, reject_split
 

--- a/docs/instructions/installation.rst
+++ b/docs/instructions/installation.rst
@@ -14,7 +14,7 @@ To install latest stable version use::
 
 To install specific version, you can specify it in the command, e.g.::
 
-    docker pull gmrukwa/divik:2.5.7
+    docker pull gmrukwa/divik:2.5.8
 
 Python package
 --------------
@@ -31,7 +31,7 @@ package::
 
 or any stable tagged version, e.g.::
 
-    pip install divik==2.5.7
+    pip install divik==2.5.8
 
 If you want to have compatibility with
 `gin-config <https://github.com/google/gin-config>`_, you can install

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages, Extension
 import sys
 import numpy
 
-__version__ = '2.5.7'
+__version__ = '2.5.8'
 
 LINUX_OPTS = {
     'extra_link_args': [
@@ -101,7 +101,6 @@ setup(
         'scikit-image>=0.14.1',
         'scikit-learn>=0.19.1',
         'tqdm>=4.11.2',
-        'typing>=3.6.2'
     ],
     setup_requires=[
         'numpy>=0.12.1',


### PR DESCRIPTION
Fixed in 2.5.8:

- removed dependency on `typing` module - it was required for Python 3.4